### PR TITLE
Log total slots at level end

### DIFF
--- a/src/scripts/wos-helper.ts
+++ b/src/scripts/wos-helper.ts
@@ -110,6 +110,7 @@ export class GameSpectator {
   private handleLevelResults(stars: any) {
     this.log(`Level ${this.currentLevel} ended with ${stars} stars`, this.wosGameLogId);
     console.log(`[WOS Helper] Level ${this.currentLevel} ended`);
+    console.log(`[WOS Helper] Total slots for level ${this.currentLevel}: ${this.currentLevelSlots.length}`);
 
     this.currentLevel += parseInt(stars);
     document.getElementById('level-title')!.innerText =


### PR DESCRIPTION
## Summary
- log the total number of slots when a level ends

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6868ac7fcc4483249228fdc2dcc68ab1