### PR TITLE
Ensure fonts resize with browser zoom

### DIFF
--- a/.astro/content.d.ts
+++ b/.astro/content.d.ts
@@ -194,6 +194,6 @@ declare module 'astro:content' {
 		LiveContentConfig['collections'][C]['loader']
 	>;
 
-	export type ContentConfig = typeof import("./../src/content.config.mjs");
+	export type ContentConfig = typeof import("../src/content.config.mjs");
 	export type LiveContentConfig = never;
 }

--- a/LIST.todo
+++ b/LIST.todo
@@ -1,4 +1,3 @@
-☐ Make the font scale more uniformly when zooming in and out on the webpage @created(Fri 06/27/2025 - 04:07 PM)
 ☐ Add a way to get the tool URL with query parameters for streaming with a browser source @created(Wed 07/02/2025 - 08:09 PM)
 ☐ Look into bug where multiple instances of the same word shows up in the possible words list @created(Fri 06/27/2025 - 03:24 PM)
 ☐ Add ability to keep track of highest level achieved for that stream/day @created(Fri 06/13/2025 - 04:46 PM)
@@ -104,6 +103,7 @@
 ☐ Add a function to send a message to the chat when the big word is discovered @created(Fri 05/09/2025 - 01:20 PM)
 
 Archive:
+  ✔ Make the font scale more uniformly when zooming in and out on the webpage @created(Fri 06/27/2025 - 04:07 PM) @done(25-07-05 16:33)
   ✔ Look into if the log of successfully adding a word is accurate. It seems to log words being added that were already there but thankfully are note duplicated @created(Fri 06/27/2025 - 04:36 PM) @done(25-07-02 20:08)
   ✔ Add capture of words left blank on the board by length and console.log them @created(Fri 06/13/2025 - 05:06 PM) @done(25-06-27 15:21)
   ✔ Add watermark/made by text to make sure credit is received @created(Fri 06/13/2025 - 04:46 PM) @done(25-06-13 17:05)

--- a/src/components/Icons/Twitch.astro
+++ b/src/components/Icons/Twitch.astro
@@ -12,6 +12,7 @@ const { width = '1em', height = '1em' } = Astro.props
   viewBox="0 0 24 24"
   width={width}
   height={height}
+  style="vertical-align: -.125em"
   xmlns="http://www.w3.org/2000/svg"
   ><path
     d="M11.571 4.714h1.715v5.143H11.57zm4.715 0H18v5.143h-1.714zM6 0L1.714 4.286v15.428h5.143V24l4.286-4.286h3.428L22.286 12V0zm14.571 11.143l-3.428 3.428h-3.429l-3 3v-3H6.857V1.714h13.714Z"

--- a/src/components/Icons/Twitch.astro
+++ b/src/components/Icons/Twitch.astro
@@ -4,7 +4,7 @@ interface Props {
   height?: string | number
 }
 
-const { width = 24, height = 24 } = Astro.props
+const { width = '1em', height = '1em' } = Astro.props
 ---
 
 <svg

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -69,7 +69,7 @@ import Twitch from '../components/Icons/Twitch.astro'
             <span id="letters-label">Letters:</span>
             <span id="letters"></span>
           </div>
-          <span>Made by: <Twitch height={10} width={10} /> clarkio</span>
+          <span>Made by: <Twitch /> clarkio</span>
           <div id="correct-words-log-container">
             <span>Correct Words: (* words missed)</span>
             <div id="correct-words-log" class="logs"></div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -69,7 +69,7 @@ import Twitch from '../components/Icons/Twitch.astro'
             <span id="letters-label">Letters:</span>
             <span id="letters"></span>
           </div>
-          <span>Made by: <Twitch /> clarkio</span>
+          <span class="made-by">Made by: <Twitch /> clarkio</span>
           <div id="correct-words-log-container">
             <span>Correct Words: (* words missed)</span>
             <div id="correct-words-log" class="logs"></div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -92,6 +92,6 @@ img {
 
 @media only screen and (min-width: 320px) and (max-width: 820px) {
   body {
-    -webkit-text-size-adjust: none;
+    -webkit-text-size-adjust: 100%;
   }
 }

--- a/src/styles/wos-helper.css
+++ b/src/styles/wos-helper.css
@@ -41,7 +41,7 @@ body {
 #correct-words-log {
   font-size: 1.5rem;
   max-height: 200px;
-  padding: 10px;
+  padding: 1rem;
   border: 1px solid #c79cff;
   height: calc(100vh - 200px);
   width: 100%;
@@ -49,7 +49,6 @@ body {
   font-family: monospace;
   white-space: pre-wrap;
   box-sizing: border-box;
-  padding: 1rem;
   color: #e1e4e8;
 }
 
@@ -70,10 +69,6 @@ summary {
   gap: 1rem;
 }
 
-#correct-words-log {
-  font-size: large;
-  width: 100%;
-}
 
 .log-container {
   display: flex;

--- a/src/styles/wos-helper.css
+++ b/src/styles/wos-helper.css
@@ -178,6 +178,12 @@ span {
   font-weight: bold;
 }
 
+.made-by {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
 h3 {
   margin: 10px 0;
 }

--- a/src/styles/wos-helper.css
+++ b/src/styles/wos-helper.css
@@ -39,7 +39,7 @@ body {
 }
 
 #correct-words-log {
-  font-size: min(4vw, 24px);
+  font-size: 1.5rem;
   max-height: 200px;
   padding: 10px;
   border: 1px solid #c79cff;
@@ -174,12 +174,12 @@ button {
 #big-word,
 #level-value,
 #hidden-letter {
-  font-size: min(3vw, 30px);
+  font-size: 1.875rem;
   font-weight: bold;
 }
 
 span {
-  font-size: min(3vw, 30px);
+  font-size: 1.875rem;
   font-weight: bold;
 }
 


### PR DESCRIPTION
## Summary
- keep text from locking to fixed sizes on mobile
- replace viewport-relative font sizes with rem sizes so text scales with zoom

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6868abd58b1c8324a79972906fac22ae