### PR TITLE
Add alphabetical sort button

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -72,6 +72,7 @@ import Twitch from '../components/Icons/Twitch.astro'
           <span>Made by: <Twitch height={10} width={10} /> clarkio</span>
           <div id="correct-words-log-container">
             <span>Correct Words: (* words missed)</span>
+            <button id="sort-correct-words-btn">Sort A-Z</button>
             <div id="correct-words-log" class="logs"></div>
           </div>
         </div>
@@ -132,6 +133,13 @@ import Twitch from '../components/Icons/Twitch.astro'
   ) as HTMLButtonElement
   wosDisconnectBtn.addEventListener('click', () => {
     spectator.disconnect()
+  })
+
+  const sortCorrectWordsBtn = document.getElementById(
+    'sort-correct-words-btn'
+  ) as HTMLButtonElement
+  sortCorrectWordsBtn.addEventListener('click', () => {
+    spectator.sortCorrectWordsAlphabetically()
   })
 
   const spectator = new GameSpectator()

--- a/src/scripts/wos-helper.ts
+++ b/src/scripts/wos-helper.ts
@@ -391,6 +391,14 @@ export class GameSpectator {
       this.currentLevelCorrectWords.join(', ');
   }
 
+  sortCorrectWordsAlphabetically() {
+    this.currentLevelCorrectWords.sort((a, b) =>
+      a.replace('*', '').localeCompare(b.replace('*', ''))
+    );
+    document.getElementById('correct-words-log')!.innerText =
+      this.currentLevelCorrectWords.join(', ');
+  }
+
   calculateHiddenLetters(bigWord: string) {
     const bigWordLetters = bigWord.split(' ').map(letter => letter.toLowerCase());
     console.log(`Big Word Letters: ${bigWordLetters.join(' ')}`, this.wosGameLogId);


### PR DESCRIPTION
## Summary
- allow manual alphabetical sort of the Correct Words list
- expose sortCorrectWordsAlphabetically method in GameSpectator

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868ad6990548324af0d8a131934652a