### PR TITLE
Add alphabetical and default sorting toggle

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -72,6 +72,8 @@ import Twitch from '../components/Icons/Twitch.astro'
           <span>Made by: <Twitch height={10} width={10} /> clarkio</span>
           <div id="correct-words-log-container">
             <span>Correct Words: (* words missed)</span>
+            <button id="sort-correct-words-btn">Sort A-Z</button>
+            <button id="sort-correct-words-default-btn">Sort by Length</button>
             <div id="correct-words-log" class="logs"></div>
           </div>
         </div>
@@ -132,6 +134,20 @@ import Twitch from '../components/Icons/Twitch.astro'
   ) as HTMLButtonElement
   wosDisconnectBtn.addEventListener('click', () => {
     spectator.disconnect()
+  })
+
+  const sortCorrectWordsBtn = document.getElementById(
+    'sort-correct-words-btn'
+  ) as HTMLButtonElement
+  sortCorrectWordsBtn.addEventListener('click', () => {
+    spectator.sortCorrectWordsAlphabetically()
+  })
+
+  const sortCorrectWordsDefaultBtn = document.getElementById(
+    'sort-correct-words-default-btn'
+  ) as HTMLButtonElement
+  sortCorrectWordsDefaultBtn.addEventListener('click', () => {
+    spectator.sortCorrectWordsByLength()
   })
 
   const spectator = new GameSpectator()

--- a/src/scripts/wos-helper.ts
+++ b/src/scripts/wos-helper.ts
@@ -385,8 +385,25 @@ export class GameSpectator {
 
   private updateCorrectWordsDisplayed(word: string) {
     this.currentLevelCorrectWords.push(word);
-    this.currentLevelCorrectWords.sort((a, b) => a.replace('*', '').length - b.replace('*', '').length);
-    // Update correct words display
+    this.sortCorrectWordsByLength();
+    this.updateCorrectWordsLog();
+  }
+
+  sortCorrectWordsAlphabetically() {
+    this.currentLevelCorrectWords.sort((a, b) =>
+      a.replace('*', '').localeCompare(b.replace('*', ''))
+    );
+    this.updateCorrectWordsLog();
+  }
+
+  sortCorrectWordsByLength() {
+    this.currentLevelCorrectWords.sort(
+      (a, b) => a.replace('*', '').length - b.replace('*', '').length
+    );
+    this.updateCorrectWordsLog();
+  }
+
+  private updateCorrectWordsLog() {
     document.getElementById('correct-words-log')!.innerText =
       this.currentLevelCorrectWords.join(', ');
   }


### PR DESCRIPTION
## Summary
- add button to revert Correct Words list to length sort
- implement `sortCorrectWordsByLength` and share DOM update helper
- wire up new button in the page script

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868ad6990548324af0d8a131934652a